### PR TITLE
support cleaning resources

### DIFF
--- a/lib/pec/command/up.rb
+++ b/lib/pec/command/up.rb
@@ -7,11 +7,11 @@ module Pec::Command
         Pec::Logger.info "make start #{config.name}"
 
         attribute = {name: config.name}
-        make_attribute(config, Pec::Handler) do |key, klass|
+        processor_matching(config, Pec::Handler) do |klass|
           attribute.deep_merge!(klass.build(config))
         end
 
-        make_attribute(attribute, Pec::Coordinate) do |key, klass|
+        processor_matching(attribute, Pec::Coordinate) do |klass|
           attribute.deep_merge!(klass.build(config, attribute))
         end
 
@@ -25,11 +25,11 @@ module Pec::Command
       end
     end
 
-    def self.make_attribute(source, klass)
+    def self.processor_matching(source, klass)
       source.keys.each do |k|
         Object.const_get(klass.to_s).constants.each do |c|
           object = Object.const_get("#{klass.to_s}::#{c}")
-          yield k, object if  k.to_s == object.kind.to_s
+          yield object if  k.to_s == object.kind.to_s
         end
       end
     end

--- a/lib/pec/core.rb
+++ b/lib/pec/core.rb
@@ -1,6 +1,6 @@
 module Pec
   module Core
-    attr_accessor :kind, :recover_kind
+    attr_accessor :kind
     def build(*args)
       raise "#{self.class.name} not defined method build"
     end

--- a/lib/pec/core.rb
+++ b/lib/pec/core.rb
@@ -1,8 +1,10 @@
 module Pec
   module Core
-    attr_accessor :kind
+    attr_accessor :kind, :recover_kind
     def build(*args)
       raise "#{self.class.name} not defined method build"
     end
+
+    def recover(*args); end
   end
 end

--- a/lib/pec/handler/networks.rb
+++ b/lib/pec/handler/networks.rb
@@ -2,6 +2,7 @@ module Pec::Handler
   class Networks
     extend Pec::Core
     self.kind = 'networks'
+    self.recover_kind = 'networks'
     autoload :IpAddress,           "pec/handler/networks/ip_address"
     autoload :AllowedAddressPairs, "pec/handler/networks/allowed_address_pairs"
 
@@ -21,6 +22,15 @@ module Pec::Handler
         {
           networks: ports.map {|port| { uuid: nil, port: port.id }}
         }
+      end
+
+      def recover(attribute)
+        Pec::Logger.notice "start port recovery"
+        attribute[:networks].each do |port|
+          Yao::Port.delete(port[:port])
+          Pec::Logger.notice "port delete id:#{port[:port]}"
+        end
+        Pec::Logger.notice "complete port recovery"
       end
 
       def validate(network)

--- a/lib/pec/handler/networks.rb
+++ b/lib/pec/handler/networks.rb
@@ -26,7 +26,7 @@ module Pec::Handler
       def recover(attribute)
         Pec::Logger.notice "start port recovery"
         attribute[:networks].each do |port|
-          Yao::Port.delete(port[:port])
+          Yao::Port.destroy(port[:port])
           Pec::Logger.notice "port delete id:#{port[:port]}"
         end
         Pec::Logger.notice "complete port recovery"

--- a/lib/pec/handler/networks.rb
+++ b/lib/pec/handler/networks.rb
@@ -2,7 +2,6 @@ module Pec::Handler
   class Networks
     extend Pec::Core
     self.kind = 'networks'
-    self.recover_kind = 'networks'
     autoload :IpAddress,           "pec/handler/networks/ip_address"
     autoload :AllowedAddressPairs, "pec/handler/networks/allowed_address_pairs"
 

--- a/spec/lib/command/up_spec.rb
+++ b/spec/lib/command/up_spec.rb
@@ -82,13 +82,13 @@ describe Pec::Command::Up do
 
     before do
         allow(Pec).to receive(:load_config).and_return(Pec.load_config("spec/fixture/load_config_003.yaml"))
-      allow(Yao::Port).to receive(:delete)
+      allow(Yao::Port).to receive(:destroy)
       allow(Yao::Server).to receive(:create).and_raise("create error")
     end
 
     it do
       is_expected.to be_truthy
-      expect(Yao::Port).to have_received(:delete).with(1)
+      expect(Yao::Port).to have_received(:destroy).with(1)
     end
   end
 end

--- a/spec/lib/command/up_spec.rb
+++ b/spec/lib/command/up_spec.rb
@@ -76,6 +76,21 @@ describe Pec::Command::Up do
       end
     end
   end
+
+  context 'recovery' do
+    subject { described_class.run([], nil) }
+
+    before do
+        allow(Pec).to receive(:load_config).and_return(Pec.load_config("spec/fixture/load_config_003.yaml"))
+      allow(Yao::Port).to receive(:delete)
+      allow(Yao::Server).to receive(:create).and_raise("create error")
+    end
+
+    it do
+      is_expected.to be_truthy
+      expect(Yao::Port).to have_received(:delete).with(1)
+    end
+  end
 end
 
 def create_rhel

--- a/spec/lib/handler/networks_spec.rb
+++ b/spec/lib/handler/networks_spec.rb
@@ -16,28 +16,9 @@ describe Pec::Handler::Networks do
       )
     )
 
-    allow(Yao::SecurityGroup).to receive(:list).and_return([
-      double(
-        id: 1,
-        tenant_id: 1,
-        name: 1
-      )
-    ])
-
-    allow(Yao::Tenant).to receive(:list).and_return([
-      double(
-        id: 1,
-        name: "test_tenant"
-      )
-    ])
-
-    allow(Yao::Subnet).to receive(:list).and_return([
-      double(
-        id: 1,
-        network_id: 1,
-        cidr: "1.1.1.0/24",
-      )
-    ])
+    allow(Yao::SecurityGroup).to receive(:list).and_return([double(id: 1, tenant_id: 1, name: 1)])
+    allow(Yao::Tenant).to receive(:list).and_return([double(id: 1, name: "test_tenant")])
+    allow(Yao::Subnet).to receive(:list).and_return([double(id: 1, network_id: 1, cidr: "1.1.1.0/24") ])
   end
 
   context 'build' do
@@ -46,16 +27,7 @@ describe Pec::Handler::Networks do
     }
 
     it do
-      expect(subject).to eq(
-        {
-          networks: [
-            {
-              uuid: nil,
-              port: 1
-            }
-          ]
-        }
-      )
+      expect(subject).to eq({networks: [{uuid: nil, port: 1}]})
     end
   end
 
@@ -66,13 +38,7 @@ describe Pec::Handler::Networks do
 
     context  'static' do
       before do
-        allow(Yao::Subnet).to receive(:list).and_return([
-          double(
-            id: 1,
-            network_id: 1,
-            cidr: "1.1.1.0/24",
-          )
-        ])
+        allow(Yao::Subnet).to receive(:list).and_return([double(id: 1, network_id: 1, cidr: "1.1.1.0/24")])
       end
 
       subject {


### PR DESCRIPTION
If it fails in the server creation, cleaning the resource

```
.make start pyama-test001.test.com
image is centos-7.1_chef-12.3_puppet-3.7
flavor is m1.small
availability_zone is nova
port create start : eth0
assgin ip : 10.10.10.10
keypair is example001
create error
recovery start pyama-test001.test.com
start port recovery
port delete id:1
complete port recovery
recovery success! pyama-test001.test.com
```