### PR TITLE
Fix pec init

### DIFF
--- a/lib/pec/command/init.rb
+++ b/lib/pec/command/init.rb
@@ -1,6 +1,6 @@
 module Pec::Command
   class Init < Base
-    def self.run
+    def self.run(_null)
       Pec::Init.show_env_setting
       Pec::Init.create_template_dir
       Pec::Init.create_sample_config


### PR DESCRIPTION
Allowing `Pec::Command::Init` to have dummy option.
(But no test... :pensive: )

reference
---

- Fail `pec init` on v0.8.1 #40