### PR TITLE
support config tenant_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ support format yaml,erb
 _default_: &def
   os_type: centos
   tenant: your_tenant
+  tenant_id: your_tenan_id(using a member roll)
   image: centos-7.1_chef-12.3_puppet-3.7
   flavor: m1.small
   availability_zone: nova

--- a/lib/pec.rb
+++ b/lib/pec.rb
@@ -64,8 +64,8 @@ module Pec
     tenant_list.find {|tenant| tenant.id == server.tenant_id}
   end
 
-  def self.fetch_tenant_by_name(config)
-    tenant_list.find {|tenant| tenant.name == config.tenant}
+  def self.get_tenant_id(config)
+    config.tenant_id || tenant_list.find {|tenant| tenant.name == config.tenant}.id
   end
 
   def self.fetch_flavor(server)
@@ -74,7 +74,7 @@ module Pec
 
   def self.server_list(config)
     @_server_list ||= {}
-    @_server_list[config.tenant] ||= Yao::Server.list_detail({tenant_id: config.tenant_id || fetch_tenant_by_name(config).id})
+    @_server_list[config.tenant] ||= Yao::Server.list_detail({tenant_id: get_tenant_id(config)})
   end
 
   def self.tenant_list

--- a/lib/pec.rb
+++ b/lib/pec.rb
@@ -74,7 +74,7 @@ module Pec
 
   def self.server_list(config)
     @_server_list ||= {}
-    @_server_list[config.tenant] ||= Yao::Server.list_detail({tenant_id: fetch_tenant_by_name(config).id})
+    @_server_list[config.tenant] ||= Yao::Server.list_detail({tenant_id: config.tenant_id || fetch_tenant_by_name(config).id})
   end
 
   def self.tenant_list

--- a/lib/pec.rb
+++ b/lib/pec.rb
@@ -34,8 +34,8 @@ module Pec
 
   def self.load_config(config_name="Pec.yaml")
     @_configure ||= []
-    ConfigFile.new(config_name).load.to_hash.reject {|k,v| k[0].match(/\_/) || k.match(/^includes$/) }.each do |host|
-      @_configure << Pec::Configure.new(host)
+    ConfigFile.new(config_name).load.to_hash.reject {|k,v| k[0].match(/\_/) || k.match(/^includes$/) }.each do |config|
+      @_configure << Pec::Configure.new(config)
     end
   rescue => e
     Pec::Logger.critical "configure error!"

--- a/lib/pec.rb
+++ b/lib/pec.rb
@@ -60,16 +60,8 @@ module Pec
     server_list(config).find {|s|s.name == config.name}
   end
 
-  def self.fetch_tenant_by_id(server)
-    tenant_list.find {|tenant| tenant.id == server.tenant_id}
-  end
-
   def self.get_tenant_id(config)
     config.tenant_id || tenant_list.find {|tenant| tenant.name == config.tenant}.id
-  end
-
-  def self.fetch_flavor(server)
-    flavor_list(server).find {|f|f.id == server.flavor['id']}
   end
 
   def self.server_list(config)

--- a/lib/pec/command/status.rb
+++ b/lib/pec/command/status.rb
@@ -2,11 +2,11 @@ module Pec::Command
   class Status < Base
     def self.task(server, config)
       if server
-        tenant_name = save_was_delete(config.name, config.tenant, :tenant) do
+        tenant_name = safe_was_delete(config.name, config.tenant, :tenant) do
           fetch_tenant(server).name
         end
 
-        flavor_name = save_was_delete(config.name, config.flavor, :flavor) do
+        flavor_name = safe_was_delete(config.name, config.flavor, :flavor) do
           fetch_flavor(server).name
         end
 
@@ -54,7 +54,7 @@ module Pec::Command
       Pec::Logger.warning @_error.join("\n") if @_error
     end
 
-    def self.save_was_delete(host_name, default ,resource_name, &blk)
+    def self.safe_was_delete(host_name, default ,resource_name, &blk)
       begin
         blk.call
       rescue

--- a/lib/pec/configure.rb
+++ b/lib/pec/configure.rb
@@ -23,14 +23,14 @@ module Pec
       @_config[1][method.to_s]
     end
 
-    def validate(host)
+    def validate(config)
       %w(
         tenant
         image
         flavor
         networks
       ).each do |k|
-        raise "#{host[0]}:host key #{k} is require" unless host[1][k]
+        raise "#{config[0]}:host key #{k} is require" unless config[1][k]
       end
     end
   end

--- a/lib/pec/handler/availability_zone.rb
+++ b/lib/pec/handler/availability_zone.rb
@@ -3,10 +3,10 @@ module Pec::Handler
     extend Pec::Core
     self.kind = 'availability_zone'
 
-    def self.build(host)
-      Pec::Logger.notice "availability_zone is #{host.availability_zone}"
+    def self.build(config)
+      Pec::Logger.notice "availability_zone is #{config.availability_zone}"
       {
-        availability_zone: host.availability_zone
+        availability_zone: config.availability_zone
       }
     end
   end

--- a/lib/pec/handler/flavor.rb
+++ b/lib/pec/handler/flavor.rb
@@ -3,14 +3,14 @@ module Pec::Handler
     extend Pec::Core
     self.kind = 'image'
 
-    def self.build(host)
-      Pec::Logger.notice "flavor is #{host.flavor}"
-      flavor_id = Yao::Flavor.list.find {|flavor| flavor.name == host.flavor}.id
+    def self.build(config)
+      Pec::Logger.notice "flavor is #{config.flavor}"
+      flavor_id = Yao::Flavor.list.find {|flavor| flavor.name == config.flavor}.id
       {
         flavorRef:  flavor_id
       }
     rescue
-      raise Pec::ConfigError, "flavor name=#{host.flavor} does not exist"
+      raise Pec::ConfigError, "flavor name=#{config.flavor} does not exist"
     end
   end
 end

--- a/lib/pec/handler/image.rb
+++ b/lib/pec/handler/image.rb
@@ -3,14 +3,14 @@ module Pec::Handler
     extend Pec::Core
     self.kind = 'image'
 
-    def self.build(host)
-      Pec::Logger.notice "image is #{host.image}"
-      image_id = Yao::Image.list.find {|image| image.name == host.image}.id
+    def self.build(config)
+      Pec::Logger.notice "image is #{config.image}"
+      image_id = Yao::Image.list.find {|image| image.name == config.image}.id
       {
         imageRef:  image_id
       }
     rescue
-      raise Pec::ConfigError, "image name=#{host.image} does not exist"
+      raise Pec::ConfigError, "image name=#{config.image} does not exist"
     end
   end
 end

--- a/lib/pec/handler/keypair.rb
+++ b/lib/pec/handler/keypair.rb
@@ -3,17 +3,17 @@ module Pec::Handler
     extend Pec::Core
     self.kind = 'keypair'
 
-    def self.build(host)
-      return({}) unless host.keypair
+    def self.build(config)
+      return({}) unless config.keypair
 
-      Pec::Logger.notice "keypair is #{host.keypair}"
-      keypair = Yao::Keypair.list.find {|k| k.name == host.keypair }
+      Pec::Logger.notice "keypair is #{config.keypair}"
+      keypair = Yao::Keypair.list.find {|k| k.name == config.keypair }
       if keypair
         {
           key_name: keypair.name,
         }
       else
-        raise Pec::ConfigError, "keypair name=#{host.keypair} does not exist"
+        raise Pec::ConfigError, "keypair name=#{config.keypair} does not exist"
       end
     end
   end

--- a/lib/pec/handler/networks.rb
+++ b/lib/pec/handler/networks.rb
@@ -71,9 +71,9 @@ module Pec::Handler
       end
 
       def security_group(host)
-        tenant = Yao::Tenant.list.find {|t| t.name == host.tenant }
+        tenant_id = host.tenant_id || Yao::Tenant.list.find {|t| t.name == host.tenant }.id
         ids = host.security_group.map do |name|
-          sg = Yao::SecurityGroup.list.find {|sg| sg.name == name && tenant.id == sg.tenant_id }
+          sg = Yao::SecurityGroup.list.find {|sg| sg.name == name && tenant_id == sg.tenant_id }
           raise "security group #{name} is not found" unless sg
           sg.id
         end

--- a/lib/pec/handler/networks.rb
+++ b/lib/pec/handler/networks.rb
@@ -9,12 +9,12 @@ module Pec::Handler
       NAME = 0
       CONFIG = 1
 
-      def build(host)
+      def build(config)
         ports = []
-        host.networks.each do |network|
+        config.networks.each do |network|
           validate(network)
           Pec::Logger.notice "port create start : #{network[NAME]}"
-          port = create_port(host, network)
+          port = create_port(config, network)
           Pec::Logger.notice "assgin ip : #{port.fixed_ips.first["ip_address"]}"
           ports << port
         end
@@ -45,12 +45,12 @@ module Pec::Handler
         end
       end
 
-      def create_port(host, network)
-        attribute = gen_port_attribute(host, network)
+      def create_port(config, network)
+        attribute = gen_port_attribute(config, network)
         Yao::Port.create(attribute)
       end
 
-      def gen_port_attribute(host, network)
+      def gen_port_attribute(config, network)
         ip = IP.new(network[CONFIG]['ip_address'])
         subnet = Yao::Subnet.list.find {|s|s.cidr == ip.network.to_s}
         attribute = {
@@ -59,8 +59,8 @@ module Pec::Handler
         }
 
         attribute.merge!(
-          security_group(host)
-        ) if host.security_group
+          security_group(config)
+        ) if config.security_group
 
         Pec.processor_matching(network[CONFIG], Pec::Handler::Networks) do |klass|
           ops = klass.build(network)
@@ -70,9 +70,9 @@ module Pec::Handler
         attribute
       end
 
-      def security_group(host)
-        tenant_id = host.tenant_id || Yao::Tenant.list.find {|t| t.name == host.tenant }.id
-        ids = host.security_group.map do |name|
+      def security_group(config)
+        tenant_id = config.tenant_id || Yao::Tenant.list.find {|t| t.name == config.tenant }.id
+        ids = config.security_group.map do |name|
           sg = Yao::SecurityGroup.list.find {|sg| sg.name == name && tenant_id == sg.tenant_id }
           raise "security group #{name} is not found" unless sg
           sg.id

--- a/lib/pec/handler/templates.rb
+++ b/lib/pec/handler/templates.rb
@@ -3,18 +3,18 @@ module Pec::Handler
     extend Pec::Core
     self.kind = 'templates'
     class << self
-      def build(host)
-        { user_data: load_template(host) }
+      def build(config)
+        { user_data: load_template(config) }
       end
 
-      def load_template(host)
-        host.templates.inject({}) do |merge_template, template|
+      def load_template(config)
+        config.templates.inject({}) do |merge_template, template|
           template.to_s.concat('.yaml') unless template.to_s.match(/.*\.yaml/)
           Pec::Logger.notice "load template #{template}"
 
           raise "#{template} not fond!" unless FileTest.exist?("user_data/#{template}")
           merge_template.deep_merge!(YAML.load_file("user_data/#{template}").to_hash)
-        end if host.templates
+        end if config.templates
       end
     end
   end

--- a/lib/pec/handler/user_data.rb
+++ b/lib/pec/handler/user_data.rb
@@ -4,15 +4,15 @@ module Pec::Handler
     autoload :Nic,  "pec/handler/user_data/nic"
     self.kind = 'user_data'
 
-    def self.build(host)
-      user_data = host.user_data || {}
-      user_data['fqdn'] = host.name if host.user_data && !host.user_data['fqdn']  
+    def self.build(config)
+      user_data = config.user_data || {}
+      user_data['fqdn'] = config.name if config.user_data && !config.user_data['fqdn']  
       { user_data: user_data }
     end
 
-    def self.post_build(host, attribute)
+    def self.post_build(config, attribute)
       Pec.processor_matching(attribute, Pec::Handler::UserData) do |klass|
-        attribute = klass.post_build(host, attribute)
+        attribute = klass.post_build(config, attribute)
       end
       attribute[:user_data] = Base64.encode64("#cloud-config\n" + attribute[:user_data].to_yaml) if attribute[:user_data]
       attribute

--- a/lib/pec/handler/user_data/nic.rb
+++ b/lib/pec/handler/user_data/nic.rb
@@ -7,10 +7,10 @@ module Pec::Handler
     self.kind = 'networks'
 
     class << self
-      def post_build(host, attribute)
-        nic = if host.os_type
+      def post_build(config, attribute)
+        nic = if config.os_type
           os = Pec::Handler::UserData::Nic.constants.find do |c|
-            Object.const_get("Pec::Handler::UserData::Nic::#{c}").os_type.include?(host.os_type)
+            Object.const_get("Pec::Handler::UserData::Nic::#{c}").os_type.include?(config.os_type)
           end
           Object.const_get("Pec::Handler::UserData::Nic::#{os}")
         else
@@ -20,7 +20,7 @@ module Pec::Handler
         attribute.deep_merge(
           {
             user_data: {
-              "write_files" => nic.gen_user_data(host.networks, ports(attribute))
+              "write_files" => nic.gen_user_data(config.networks, ports(attribute))
             }
           }
         )


### PR DESCRIPTION
Pec.yaml
```
example.server001:
  tenant_id:xxxxxxxxxxxxx
```
because there is not access tenant list and not the administrator, using a member roll

