### PR TITLE
added config file option

### DIFF
--- a/lib/pec.rb
+++ b/lib/pec.rb
@@ -34,7 +34,7 @@ module Pec
 
   def self.load_config(config_name="Pec.yaml")
     @_configure ||= []
-    ConfigFile.new(config_name).load.to_hash.reject {|k,v| k[0].match(/\_/) || k.match(/^includes$/) }.each do |config|
+    ConfigFile.new(Pec.optins[:config_file]|| config_name).load.to_hash.reject {|k,v| k[0].match(/\_/) || k.match(/^includes$/) }.each do |config|
       @_configure << Pec::Configure.new(config)
     end
   rescue => e

--- a/lib/pec.rb
+++ b/lib/pec.rb
@@ -34,7 +34,7 @@ module Pec
 
   def self.load_config(config_name="Pec.yaml")
     @_configure ||= []
-    ConfigFile.new(Pec.options[:config_file]|| config_name).load.to_hash.reject {|k,v| k[0].match(/\_/) || k.match(/^includes$/) }.each do |config|
+    ConfigFile.new(Pec.options[:config_file] || config_name).load.to_hash.reject {|k,v| k[0].match(/\_/) || k.match(/^includes$/) }.each do |config|
       @_configure << Pec::Configure.new(config)
     end
   rescue => e

--- a/lib/pec.rb
+++ b/lib/pec.rb
@@ -34,7 +34,7 @@ module Pec
 
   def self.load_config(config_name="Pec.yaml")
     @_configure ||= []
-    ConfigFile.new(Pec.optins[:config_file]|| config_name).load.to_hash.reject {|k,v| k[0].match(/\_/) || k.match(/^includes$/) }.each do |config|
+    ConfigFile.new(Pec.options[:config_file]|| config_name).load.to_hash.reject {|k,v| k[0].match(/\_/) || k.match(/^includes$/) }.each do |config|
       @_configure << Pec::Configure.new(config)
     end
   rescue => e

--- a/lib/pec/cli.rb
+++ b/lib/pec/cli.rb
@@ -8,7 +8,7 @@ module Pec
       _sub_command([], options)
     end
 
-    desc 'up [HOSTNAME1, HOSTNAME2, ...]', 'create vm by Pec.yaml'
+    desc 'up [HOSTNAME1, HOSTNAME2, ...]', 'vm create'
     def up(*filter_hosts)
       _sub_command(filter_hosts, options)
     end

--- a/lib/pec/cli.rb
+++ b/lib/pec/cli.rb
@@ -1,6 +1,7 @@
 require 'pec'
 module Pec
   class CLI < Thor
+    option :config_file , type: :string, aliases: "-c"
 
     desc 'init', 'create sample config'
     def init

--- a/lib/pec/cli.rb
+++ b/lib/pec/cli.rb
@@ -1,7 +1,7 @@
 require 'pec'
 module Pec
   class CLI < Thor
-    option :config_file , type: :string, aliases: "-c"
+    class_option :config_file , type: :string, aliases: "-c"
 
     desc 'init', 'create sample config'
     def init

--- a/lib/pec/config_file.rb
+++ b/lib/pec/config_file.rb
@@ -25,7 +25,7 @@ module Pec
             raise "not match file type must be yaml or erb"
         end
       else
-        raise "not file exiets! #{file_name}"
+        raise " #{file_name} not exiets!"
       end
     end
   end


### PR DESCRIPTION
It made it possible specify a configuration file in the argument

```
$ pec status -c /path/to/Pec.yaml
$ pec --help
Commands:
  pec --version, -v                        # print the version
…
Options:
  -c, [--config-file=CONFIG_FILE]  ★
```

