### PR TITLE
fix uuid is string

### DIFF
--- a/lib/pec/handler/networks.rb
+++ b/lib/pec/handler/networks.rb
@@ -20,7 +20,7 @@ module Pec::Handler
           ports << port
         end
         {
-          networks: ports.map {|port| { uuid: nil, port: port.id }}
+          networks: ports.map {|port| { uuid: '', port: port.id }}
         }
       rescue Yao::Conflict => e
         raise(Pec::PortError.new(ports), e)

--- a/lib/pec/port_error.rb
+++ b/lib/pec/port_error.rb
@@ -2,7 +2,7 @@ class Pec::PortError < StandardError
   attr_accessor :attribute
   def initialize(ports)
     self.attribute = {
-      networks: ports.map {|port| { uuid: nil, port: port.id }}
+      networks: ports.map {|port| { uuid: '', port: port.id }}
     } if ports
   end
 end

--- a/spec/lib/command/up_spec.rb
+++ b/spec/lib/command/up_spec.rb
@@ -156,7 +156,7 @@ def create_rhel
     :imageRef => 1,
     :flavorRef => 1,
     :availability_zone => "nova",
-    :networks => [{:uuid => nil, :port => 1}],
+    :networks => [{:uuid => '', :port => 1}],
     :user_data =>  "I2Nsb3VkLWNvbmZpZwotLS0KaG9zdG5hbWU6IHB5YW1hLXRlc3QwMDEKdXNl\ncnM6Ci0gbmFtZTogMQpmcWRuOiBweWFtYS10ZXN0MDAxLnRlc3QuY29tCndy\naXRlX2ZpbGVzOgotIGNvbnRlbnQ6IHwKICAgIE5BTUU9ZXRoMAogICAgREVW\nSUNFPWV0aDAKICAgIFRZUEU9RXRoZXJuZXQKICAgIE9OQk9PVD15ZXMKICAg\nIEhXQUREUj0wMDowMDowMDowMDowMDowMAogICAgTkVUTUFTSz0yNTUuMjU1\nLjI1NS4wCiAgICBJUEFERFI9MTAuMTAuMTAuMTAKICAgIEJPT1RQUk9UTz1z\ndGF0aWMKICAgIEdBVEVXQVk9MS4xLjEuMjU0CiAgb3duZXI6IHJvb3Q6cm9v\ndAogIHBhdGg6ICIvZXRjL3N5c2NvbmZpZy9uZXR3b3JrLXNjcmlwdHMvaWZj\nZmctZXRoMCIKICBwZXJtaXNzaW9uczogJzA2NDQnCg==\n",
    :key_name => "example001"
   }
@@ -168,7 +168,7 @@ def create_ubuntu
     :imageRef => 2,
     :flavorRef => 1,
     :availability_zone => "nova",
-    :networks => [{:uuid => nil, :port => 1}],
+    :networks => [{:uuid => '', :port => 1}],
     :user_data =>  "I2Nsb3VkLWNvbmZpZwotLS0KaG9zdG5hbWU6IHB5YW1hLXRlc3QwMDEKdXNl\ncnM6Ci0gbmFtZTogMQpmcWRuOiBweWFtYS10ZXN0MDAyLnRlc3QuY29tCndy\naXRlX2ZpbGVzOgotIGNvbnRlbnQ6IHwKICAgIE5BTUU9ZXRoMAogICAgREVW\nSUNFPWV0aDAKICAgIFRZUEU9RXRoZXJuZXQKICAgIE9OQk9PVD15ZXMKICAg\nIEhXQUREUj0wMDowMDowMDowMDowMDowMAogICAgTkVUTUFTSz0yNTUuMjU1\nLjI1NS4wCiAgICBJUEFERFI9MTAuMTAuMTAuMTAKICAgIEJPT1RQUk9UTz1z\ndGF0aWMKICAgIEdBVEVXQVk9MS4xLjEuMjU0CiAgb3duZXI6IHJvb3Q6cm9v\ndAogIHBhdGg6ICIvZXRjL3N5c2NvbmZpZy9uZXR3b3JrLXNjcmlwdHMvaWZj\nZmctZXRoMCIKICBwZXJtaXNzaW9uczogJzA2NDQnCg==\n", :key_name => "example001"
   }
 end
@@ -179,7 +179,7 @@ def create_basic_1
     :imageRef => 1,
     :flavorRef => 1,
     :availability_zone => "nova",
-    :networks => [{:uuid => nil, :port => 1}],
+    :networks => [{:uuid => '', :port => 1}],
     :user_data => "I2Nsb3VkLWNvbmZpZwotLS0KdXNlcnM6Ci0gbmFtZTogMgotIG5hbWU6IDEK\naG9zdG5hbWU6IHB5YW1hLXRlc3QwMDEKZnFkbjogcHlhbWEtdGVzdDAwMS50\nZXN0LmNvbQp3cml0ZV9maWxlczoKLSBjb250ZW50OiB8CiAgICBOQU1FPWV0\naDAKICAgIERFVklDRT1ldGgwCiAgICBUWVBFPUV0aGVybmV0CiAgICBPTkJP\nT1Q9eWVzCiAgICBIV0FERFI9MDA6MDA6MDA6MDA6MDA6MDAKICAgIE5FVE1B\nU0s9MjU1LjI1NS4yNTUuMAogICAgSVBBRERSPTEwLjEwLjEwLjEwCiAgICBC\nT09UUFJPVE89c3RhdGljCiAgICBHQVRFV0FZPTEuMS4xLjI1NAogIG93bmVy\nOiByb290OnJvb3QKICBwYXRoOiAiL2V0Yy9zeXNjb25maWcvbmV0d29yay1z\nY3JpcHRzL2lmY2ZnLWV0aDAiCiAgcGVybWlzc2lvbnM6ICcwNjQ0Jwo=\n",
     :key_name => "example001"
   }
@@ -191,7 +191,7 @@ def create_basic_2
     :imageRef => 1,
     :flavorRef => 1,
     :availability_zone => "nova",
-    :networks => [{:uuid => nil, :port => 1}],
+    :networks => [{:uuid => '', :port => 1}],
     :user_data => "I2Nsb3VkLWNvbmZpZwotLS0KdXNlcnM6Ci0gbmFtZTogMgotIG5hbWU6IDEK\naG9zdG5hbWU6IHB5YW1hLXRlc3QwMDEKZnFkbjogcHlhbWEtdGVzdDAwMi50\nZXN0LmNvbQp3cml0ZV9maWxlczoKLSBjb250ZW50OiB8CiAgICBOQU1FPWV0\naDAKICAgIERFVklDRT1ldGgwCiAgICBUWVBFPUV0aGVybmV0CiAgICBPTkJP\nT1Q9eWVzCiAgICBIV0FERFI9MDA6MDA6MDA6MDA6MDA6MDAKICAgIE5FVE1B\nU0s9MjU1LjI1NS4yNTUuMAogICAgSVBBRERSPTEwLjEwLjEwLjEwCiAgICBC\nT09UUFJPVE89c3RhdGljCiAgICBHQVRFV0FZPTEuMS4xLjI1NAogIG93bmVy\nOiByb290OnJvb3QKICBwYXRoOiAiL2V0Yy9zeXNjb25maWcvbmV0d29yay1z\nY3JpcHRzL2lmY2ZnLWV0aDAiCiAgcGVybWlzc2lvbnM6ICcwNjQ0Jwo=\n",
     :key_name => "example001"
   }

--- a/spec/lib/handler/networks_spec.rb
+++ b/spec/lib/handler/networks_spec.rb
@@ -28,7 +28,7 @@ describe Pec::Handler::Networks do
     }
 
     it do
-      expect(subject).to eq({networks: [{uuid: nil, port: 1}]})
+      expect(subject).to eq({networks: [{uuid: '', port: 1}]})
     end
   end
 


### PR DESCRIPTION
```
make start  pec.com
...
★　Invalid input for field/attribute uuid. Value: None. None is not of type 'string'
recovery start pec.pb
start port recovery
port delete id:366ecbdb-8872-45fb-b21a-4ceb8bb9da16
port delete id:274ed5e9-31f0-43ec-8c15-452ef8a1f334
complete port recovery
```