### PR TITLE
Delete the port created at instance deletion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in pec.gemspec
 gemspec
 gem "codeclimate-test-reporter", group: :test, require: nil
+gem 'json', github: 'flori/json', branch: 'v1.8'

--- a/lib/pec/command/destroy.rb
+++ b/lib/pec/command/destroy.rb
@@ -5,6 +5,12 @@ module Pec::Command
         Pec::Logger.notice "not be created #{config.name}"
       else
         if Pec.options[:force] || Thor.new.yes?("#{config.name}: Are you sure you want to destroy the '#{config.name}' VM? [y/N]")
+          ports = Yao::Port.list({ device_id: server.id })
+          ports.each do |port|
+            Yao::Port.destroy(port.id)
+            Pec::Logger.notice "port delete id:#{port.id}"
+          end if ports
+
           Yao::Server.destroy(server.id)
           Pec::Logger.info "#{config.name} is deleted!"
         end

--- a/pec.gemspec
+++ b/pec.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.add_dependency 'json'
   spec.add_dependency 'thor', '~> 0.19.1'
   spec.add_dependency 'yao', '~> 0.2.13'
   spec.add_dependency 'ruby-ip', '~> 0.9.3'

--- a/spec/lib/command/destroy_spec.rb
+++ b/spec/lib/command/destroy_spec.rb
@@ -10,6 +10,10 @@ describe Pec::Command::Destroy do
       double(id: 2, name: "include_test_tenant"),
     ])
 
+    allow(Yao::Port).to receive(:destroy)
+    allow(Yao::Port).to receive(:list).and_return([
+      double(id: 1)
+    ])
     allow(Yao::Server).to receive(:list_detail).and_return(servers)
   end
 
@@ -37,6 +41,7 @@ describe Pec::Command::Destroy do
           expect { subject }.not_to raise_error
           expect(Yao::Server).to have_received(:destroy).with(1)
           expect(Yao::Server).to have_received(:destroy).with(2)
+          expect(Yao::Port).to have_received(:destroy).with(1).twice
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
 require 'pec'
 require 'rspec'
+require 'simplecov'
+SimpleCov.start
 
 Dir["./support/**/*.rb"].each do |f|
   require f


### PR DESCRIPTION
When deleting an instance with openstack, delete the port because it is not deleted