### PR TITLE
Support client_key/client_cert/region_name

### DIFF
--- a/lib/pec.rb
+++ b/lib/pec.rb
@@ -25,6 +25,9 @@ module Pec
       username ENV["OS_USERNAME"]
       password ENV["OS_PASSWORD"]
       tenant_name _tenant_name
+      client_cert ENV['OS_CERT']
+      client_key  ENV['OS_KEY']
+      region_name ENV['OS_REGION_NAME']
     end
   end
 


### PR DESCRIPTION
Yao now supports client_key/client_cert/regien_name the following commits:

* https://github.com/yaocloud/yao/commit/ccb88ae0925761c310a24f7d002307bd7de5aaf3
* https://github.com/yaocloud/yao/commit/ed3c00ede655a74e668eba8b1d870264d5cf0600